### PR TITLE
Ajout de la gestion de la concurrence

### DIFF
--- a/emf-pixel-war_app/src/main/java/app/workers/DbWorker.java
+++ b/emf-pixel-war_app/src/main/java/app/workers/DbWorker.java
@@ -110,6 +110,7 @@ public class DbWorker implements DbWorkerItf {
   public void modifier(Pixel p) throws MyDBException {
     try {
       et.begin();
+      em.find(Pixel.class, p.getPkPixel(), LockModeType.PESSIMISTIC_WRITE);
       em.merge(p);
       et.commit();
     } catch (Exception ex) {


### PR DESCRIPTION
On met le modifier en mode pessimiste pour bien avoir une exception, et qu'elle soit visible sur l'interface